### PR TITLE
Show error message if the genyshell cannot be found

### DIFF
--- a/README
+++ b/README
@@ -5,6 +5,9 @@ This script replays a gpx file and outputs to geanyshell
 Example usage:
 python playback-gpx.py -i 1 -r "-r 192.168.56.101" "docs/South On Topanga(1).gpx"
 
+02/01/2018
+
+show an error message if the genyshell cannot be found
 
 08/21/2014
 

--- a/playback-gpx.py
+++ b/playback-gpx.py
@@ -89,6 +89,11 @@ if __name__=='__main__':
 
     logging.debug("using genymotion shell at " + options.command)
 
+    if not os.path.exists(options.command):
+        logging.error("genymotion shell not found at " + options.command)
+        logging.info("specify the path of genymotion shell using the -g flag")
+        quit()
+
     for path in args:
         if not os.path.exists(path):
             logging.error(path + " not found")


### PR DESCRIPTION
If the genyshell cannot be found at its default location or at the location that the user provided using the `-g` flag the script used to end with a cryptic exception.

My change will show an error message and advice the user to use the `-g` flag to specify the correct genyshell path.